### PR TITLE
Detect and mitigated janet and/or user created circular references.

### DIFF
--- a/src/builtins.janet
+++ b/src/builtins.janet
@@ -138,6 +138,7 @@
 (put hermes-env 'sh/$?  @{:value sh/$?})
 (put hermes-env 'sh/glob  @{:value sh/glob})
 (put hermes-env '*pkg-noop-build* @{:value (fn [&] nil)})
+(put hermes-env '*circular-reference* @{:value '*circular-reference*})
 (put hermes-env '_hermes/setuid @{:value _hermes/setuid})
 (put hermes-env '_hermes/setgid @{:value _hermes/setgid})
 (put hermes-env '_hermes/seteuid @{:value _hermes/seteuid})

--- a/src/hermes.h
+++ b/src/hermes.h
@@ -14,6 +14,12 @@ typedef struct {
 } HashState;
 
 typedef struct {
+    // Packages are only allowed to depend on
+    // sequence numbers created before them.
+    // We use this to enforce an absense of circular
+    // dependency.
+    Janet sequence_number;
+
     char frozen;  /* Once a package is frozen,
                      It's hash has been computed and
                      the path on disk has been computed.


### PR DESCRIPTION
It was possible to create circular references quite easily in two ways,
deliberately, or accidentally.

Deliberately is easy using mutable types:

(def list @[])
(def p (pkg :builder (fn [] (pp list)) ))
(array/append list p)

The user can also accidentally create one via janet env references:

(defn f [v]
  (def p1 (pkg :builder |(pp v)))
  (def p2 (pkg :builder |(pp v))))

(def [p1 p2] (f))

This patch addresses both cases by assigning each pkg a sequence number.
Packages may only depend on those created earlier in time. Accidental circular
references simply are unmarshalled into the build env as '*circular-reference*
and attempting to use them will most likely result in a build error.

Janet def and import semantics match what we want close enough to maybe mean
we don't need to think much more about this issue. Otherwise we can investigate
more robust error reporting.