### PR TITLE
Fix cp signature checking.

### DIFF
--- a/doc/man/hermes-cp.1.md
+++ b/doc/man/hermes-cp.1.md
@@ -23,7 +23,6 @@ Sending packages is done atomically, and therefore is crash safe and also safe t
 
 To ensure package store integrity, the receiving package store must have
 the public key of the sending package store added to it's set of trusted store keys (see hermes-package-store(7)).
-The `--allow-untrusted` option can be passed to `hermes cp` by the owner of the destination store owner to bypass this check.
 
 The store path of the FROM and TO stores may differ, but if they do differ,
 packages may not be runnable in place as absolute PATH references will not be correct.
@@ -32,10 +31,6 @@ This use case is generally used for intermediate package transfers.
 ## OPTIONS
 
 ```
---allow-untrusted 
-  
-  Allow the destination to ignore failed trust challenges if run by the store owner.
-
 -t, --to-store VALUE 
   
   The store to copy into.

--- a/src/hermes-main.janet
+++ b/src/hermes-main.janet
@@ -380,9 +380,6 @@ Browse the latest manual at:
 
 (def- cp-params
   ["Copy a package closure between package stores."
-   "allow-untrusted"
-   {:kind :flag
-    :help "Allow the destination to ignore failed trust challenges if run by the store owner."}
    "to-store"
    {:kind :option
     :short "t"
@@ -433,8 +430,7 @@ Browse the latest manual at:
           ;(if to ["-o" to] [])]
         @["hermes-pkgstore" "recv"
           ;store-args
-          ;(if to ["-o" to] [])
-          ;(if (parsed-args "allow-untrusted") ["--allow-untrusted"] [])])))
+          ;(if to ["-o" to] [])])))
 
   (def [pipe1< pipe1>] (posix-spawn/pipe))
   (def [pipe2< pipe2>] (posix-spawn/pipe))

--- a/src/hermes-pkgstore-main.janet
+++ b/src/hermes-pkgstore-main.janet
@@ -246,10 +246,7 @@ Browse the latest manual at:
    "output"
    {:kind :option
     :short "o"
-    :help "Path to where package output link will be created."}
-   "allow-untrusted"
-   {:kind :flag
-    :help "Allow the receive end store owner to ignore failed trust challenges"}])
+    :help "Path to where package output link will be created."}])
 
 (defn- recv
   []
@@ -269,7 +266,7 @@ Browse the latest manual at:
   (pkgstore/open-pkg-store store user-info)
 
   (pkgstore/recv-pkg-closure
-    stdout stdin (parsed-args "output") :allow-untrusted (parsed-args "allow-untrusted")))
+    stdout stdin (parsed-args "output")))
 
 (defn sanitize-env
   []


### PR DESCRIPTION
When we receive packages to a package store, we can only
accept signed packages. Before we were just verifying the
package stream via a challenge, however this is insufficient,
as once the challenge was verified an attacker may start
to send unsigned tarballs.

The new protocol essentially works like this:

-> Send signed package closure.
<- Reply with filtered package closure.
-> Send signed tarballs, one per package.