### PR TITLE
Fix double symbol when compiling hermes

### DIFF
--- a/src/pkgfreeze.c
+++ b/src/pkgfreeze.c
@@ -25,7 +25,7 @@
 #include "hermes.h"
 
 /* Lead bytes in hashing protocol */
-enum {
+static enum {
     LB_REAL = 200,
     LB_NIL,
     LB_FALSE,


### PR DESCRIPTION
This commit fixes the error:

    compiling and linking build/hermes...
    /usr/bin/ld: .../janet/bin/../lib/libjanet.a(janet.o):(.bss+0x0): multiple definition of `LeadBytes'; build/_hermes.a(src___pkgfreeze.static.o):(.bss+0x0): first defined here

This makes the redefined enum static, therefore, local to this file.